### PR TITLE
optimize linearizable read

### DIFF
--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -1,0 +1,41 @@
+package meta
+
+import (
+	"context"
+	"strconv"
+
+	"google.golang.org/grpc/metadata"
+)
+
+const redirectTimes string = "redirect_times"
+
+func RedirectTimes(ctx context.Context) (int, error) {
+	m, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return 0, nil
+	}
+	if rts := m.Get(redirectTimes); len(rts) == 0 {
+		return 0, nil
+	} else {
+		if t, err := strconv.Atoi(rts[0]); err != nil {
+			return 0, err
+		} else {
+			return t, nil
+		}
+	}
+}
+
+func RedirectCtx(ctx context.Context) (context.Context, error) {
+	times, err := RedirectTimes(ctx)
+	if err != nil {
+		return nil, err
+	}
+	md := metadata.New(map[string]string{
+		redirectTimes: strconv.Itoa(times + 1),
+	})
+	if oldMD, ok := metadata.FromIncomingContext(ctx); ok {
+		md = metadata.Join(oldMD.Copy(), md)
+	}
+	newCtx := metadata.NewOutgoingContext(ctx, md)
+	return newCtx, nil
+}

--- a/internal/server.go
+++ b/internal/server.go
@@ -51,7 +51,7 @@ func NewServer(opts *Options) (*Server, error) {
 		return nil, err
 	}
 
-	n := storage.NewStore(fsm)
+	n := storage.NewNode(fsm, opts.NodeID)
 	r, err := newRaft(opts.RaftAddr, opts.NodeID, opts.LogDir, opts.JoinAddr, fsm, n.ObChan())
 	if err != nil {
 		return nil, err

--- a/internal/service/controller_service.go
+++ b/internal/service/controller_service.go
@@ -8,7 +8,6 @@ import (
 	"github.com/alwaysLinger/rbkv/pb"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/reflection"
 	"google.golang.org/grpc/status"
 )
 
@@ -46,7 +45,6 @@ func (s *ControllerService) Run(addr string) error {
 
 	s.server = grpc.NewServer(grpc.UnaryInterceptor(errServerUnaryInterceptor()))
 	pb.RegisterControllerServer(s.server, s)
-	reflection.Register(s.server)
 	if err := s.server.Serve(lis); err != nil {
 		fmt.Printf("controller server stopped: %v\n", err)
 		return err

--- a/internal/service/kv_service.go
+++ b/internal/service/kv_service.go
@@ -9,7 +9,6 @@ import (
 	"github.com/alwaysLinger/rbkv/pb"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/reflection"
 	"google.golang.org/grpc/status"
 )
 
@@ -89,11 +88,10 @@ func (s *KVService) Run(addr string) error {
 		return err
 	}
 	s.server = grpc.NewServer(
-		grpc.UnaryInterceptor(errServerUnaryInterceptor()),
+		grpc.ChainUnaryInterceptor(redirectServerUnaryInterceptor(1), errServerUnaryInterceptor()),
 		grpc.StreamInterceptor(errServerStreamInterceptor()),
 	)
 	pb.RegisterRbdkvServer(s.server, s)
-	reflection.Register(s.server)
 	if err := s.server.Serve(lis); err != nil {
 		fmt.Printf("kv server stopped: %v\n", err)
 		return err


### PR DESCRIPTION
Modify the implementation of linearizable reads by implementing read requests through the Raft log mechanism, waiting for the leader to process, and returning results to the requesting party. Instead of having the receiving node wait for the appliedIndex to catch up with the committed index